### PR TITLE
Fix a state-management bug resulting in inability to leave and rejoin…

### DIFF
--- a/react-demo/src/components/App/App.js
+++ b/react-demo/src/components/App/App.js
@@ -58,9 +58,18 @@ export default function App() {
    */
   const startLeavingCall = useCallback(() => {
     if (!callObject) return;
-    setAppState(STATE_LEAVING);
-    callObject.leave();
-  }, [callObject]);
+    // If we're in the error state, we've already "left", so just clean up
+    if (appState === STATE_ERROR) {
+      callObject.destroy().then(() => {
+        setRoomUrl(null);
+        setCallObject(null);
+        setAppState(STATE_IDLE);
+      });
+    } else {
+      setAppState(STATE_LEAVING);
+      callObject.leave();
+    }
+  }, [callObject, appState]);
 
   /**
    * If a room's already specified in the page's URL when the component mounts,


### PR DESCRIPTION
… a meeting after a meeting-ending error occurs.

The "normal" (non-error) leave-meeting flow involves invoking `leave()`, which then eventually results in a `left-meeting` event, which triggers our handler, which does the meeting cleanup. When we're in an error state, though, calling `leave()` is a no-op—we've already "left"—so we can't rely on it to trigger the `left-meeting` event. Instead, we can do the cleanup right away.