### PR TITLE
Changed width measurement to px instead of x in TrayButton.css

### DIFF
--- a/react-demo/src/components/TrayButton/TrayButton.css
+++ b/react-demo/src/components/TrayButton/TrayButton.css
@@ -1,5 +1,5 @@
 .tray-button {
-  width: 44x;
+  width: 44px;
   height: 44px;
   border: none;
   background-color: transparent;


### PR DESCRIPTION
A Daily user flagged a typo in TrayButton.css ([Issue 9](https://github.com/daily-co/daily-demos/issues/9)). 

This PR fixes that issue by adding a "px" instead of "x" in TrayButton.css. 