### PR TITLE
chore: update to use public GitHub Action

### DIFF
--- a/.github/workflows/elastic-beanstalk-deploy.yml
+++ b/.github/workflows/elastic-beanstalk-deploy.yml
@@ -27,14 +27,8 @@ jobs:
           region: us-east-1
           use_existing_version_if_available: true
           deployment_package: deploy.zip
-      - name: Checkout private GitHub Action
-        uses: actions/checkout@v2
-        with:
-          repository: daily-co/create-tag-action
-          token: ${{ secrets.SECRET_GITHUB_ACTIONS_PAT }}
-          path: .github/actions/create-tag-action
       - name: Tag the deployment
-        uses: ./.github/actions/create-tag-action
+        uses: daily-co/create-tag-action@v1.0
         with:
           app-name: daily-demos
           environment: prod


### PR DESCRIPTION
Making our GitHub action public eliminates the need to check out its source code using a step in the workflow.  (GitHub Actions doesn't support private repositories as easily as it does public repositories.)