### PR TITLE
Feat/demo fullscreen prebuilt ui [Issue 38]

### DIFF
--- a/static-demos/fullscreen-prebuilt-UI/fullscreen-prebuilt-ui.css
+++ b/static-demos/fullscreen-prebuilt-UI/fullscreen-prebuilt-ui.css
@@ -1,0 +1,21 @@
+body {
+  display: flex;
+  background-color: #1f2d3d;
+  color: #e6eaef;
+  font-family: 'GraphikRegular', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+#intro-text {
+  margin: auto;
+}
+
+#start-button {
+  margin: auto;
+  font-family: 'GraphikRegular', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 100%; 
+  color: #1f2d3d; 
+  font-weight: bold; 
+  background-color: #62a60f; 
+  border-radius: 15%; 
+  padding: 2%; 
+}

--- a/static-demos/fullscreen-prebuilt-UI/fullscreen-prebuilt-ui.html
+++ b/static-demos/fullscreen-prebuilt-UI/fullscreen-prebuilt-ui.html
@@ -6,6 +6,7 @@
     <!-- Helper script creates a demo room under the api-demo.daily.co
      domain. Replace this in your production code with a function that creates rooms within your own domain. -->
     <script src="../shared-assets/create-demo-room.js"></script>
+    <link rel="stylesheet" href="fullscreen-prebuilt-ui.css">
   </head>
   <body>
     <p id="intro-text">
@@ -13,11 +14,9 @@
       Open your browser console to watch your call stats. Then...
     </p>
 
-    <p>
       <button id="start-button" onclick="run()">
         Click here to start call
-      </button>
-    </p>
+      </button> 
 
     <script>
       // Helper function prints events to the console

--- a/static-demos/fullscreen-prebuilt-UI/fullscreen-prebuilt-ui.html
+++ b/static-demos/fullscreen-prebuilt-UI/fullscreen-prebuilt-ui.html
@@ -1,0 +1,107 @@
+<html>
+  <head>
+    <title>Daily prebuilt UI fullscreen embed demo</title>
+    <!-- This library, bundled and minimized -->
+    <script src="https://unpkg.com/@daily-co/daily-js"></script>
+    <!-- Helper script creates a demo room under the api-demo.daily.co
+     domain. Replace this in your production code with a function that creates rooms within your own domain. -->
+    <script src="../shared-assets/create-demo-room.js"></script>
+  </head>
+  <body>
+    <p id="intro-text">
+      Thanks for trying a Daily demo!<br />
+      Open your browser console to watch your call stats. Then...
+    </p>
+
+    <p>
+      <button id="start-button" onclick="run()">
+        Click here to start call
+      </button>
+    </p>
+
+    <script>
+      // Helper function prints events to the console
+      // Will be passed as callback to callFrame event handlers
+      function showEvent(e) {
+        console.log('video call event -->', e);
+      }
+
+      async function run() {
+        // Create a short-lived demo room, using the imported script
+        // If you prefer to hard-code your own link for testing, replace the function call with your own URL, e.g.
+        // room = { url: 'https://your-domain.daily.co/hello' }
+        room = await createMtgRoom();
+
+        // Create the DailyIframe, passing styling properties to make it fullscreen
+        window.callFrame = window.DailyIframe.createFrame({
+          iframeStyle: {
+            position: 'fixed',
+            border: 0,
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+          },
+        });
+
+        // Install event handlers
+        callFrame
+          .on('loading', showEvent)
+          .on('loaded', showEvent)
+          .on('started-camera', showEvent)
+          .on('camera-error', showEvent)
+          .on('joining-meeting', showEvent)
+          .on('joined-meeting', showEvent)
+          .on('participant-joined', showEvent)
+          .on('participant-updated', showEvent)
+          .on('participant-left', showEvent)
+          .on('recording-started', showEvent)
+          .on('recording-stopped', showEvent)
+          .on('recording-stats', showEvent)
+          .on('recording-error', showEvent)
+          .on('recording-upload-completed', showEvent)
+          .on('app-message', showEvent)
+          .on('input-event', showEvent)
+          .on('error', showEvent)
+          // Add a leave handler to clean things up
+          .on('left-meeting', leave);
+
+        // Join the room
+        await callFrame.join({
+          url: room.url,
+          showLeaveButton: true,
+        });
+
+        // Leave handler
+        function leave(e) {
+          showEvent(e);
+          callFrame.destroy();
+          document.getElementById('intro-text').style.display = 'initial';
+          document.getElementById('start-button').style.display = 'initial';
+        }
+
+        // Once a call starts running, hide the start button and prompts
+        document.getElementById('intro-text').style.display = 'none';
+        document.getElementById('start-button').style.display = 'none';
+
+        // Log information about the call to the console
+        console.log(
+          ' You are connected to',
+          callFrame.properties.url,
+          '\n',
+          'Use the window.callFrame object to experiment with',
+          '\n',
+          'controlling this call. For example, in the console',
+          '\n',
+          'try',
+          '\n',
+          '    callFrame.participants()',
+          '\n',
+          '    callFrame.setLocalVideo(false)',
+          '\n',
+          '    callFrame.startScreenShare()'
+        );
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
We received feedback that a demo featuring our prebuilt UI at fullscreen would be helpful ([Issue 38](https://github.com/daily-co/daily-demos/issues/38), [DEV-309](https://linear.app/dailyco/issue/DEV-309/create-fullscreen-iframe-demo)). 

So, this PR addresses that request! We added in a `fullscreen-prebuilt-ui` folder under the `static-demos` directory that displays a minor-ly styled intro screen and button to the user, prompting them to start the call, and then jumps into an embedded prebuilt UI call at fullscreen. 

**To review** 
1. Make sure you're in the daily-demos repository
2. git checkout feat/demo-fullscreen-prebuultUI
3. cd static-demos
4. npm run dev or npm run start
5. In your browser, head to `http://localhost:3001/static-demos/fullscreen-prebuilt-UI/fullscreen-prebuilt-ui.html` 
6. Start a call.

Thanks, as always, for feedback! I'm happy to change or remove styling, etc. 