### PR TITLE
Added participantName to localitems in first attempt to display name

### DIFF
--- a/react-demo/src/components/App/App.js
+++ b/react-demo/src/components/App/App.js
@@ -92,7 +92,6 @@ export default function App() {
     if (pageUrl === window.location.href) return;
     window.history.replaceState(null, null, pageUrl);
   }, [roomUrl]);
-
   /**
    * Uncomment to attach call object to window for debugging purposes.
    */

--- a/react-demo/src/components/Call/Call.js
+++ b/react-demo/src/components/Call/Call.js
@@ -145,6 +145,7 @@ export default function Call() {
           isLocalPerson={isLocal(id)}
           isLarge={isLarge}
           isLoading={callItem.isLoading}
+          participantName={callItem.participantName}
           onClick={
             isLocal(id)
               ? null

--- a/react-demo/src/components/Call/callState.js
+++ b/react-demo/src/components/Call/callState.js
@@ -14,6 +14,7 @@ const initialCallState = {
       isLoading: true,
       audioTrack: null,
       videoTrack: null,
+      participantName: '',
     },
   },
   clickAllowTimeoutFired: false,
@@ -91,6 +92,7 @@ function getCallItems(participants, prevCallItems) {
       isLoading: !hasLoaded && missingTracks,
       audioTrack: participant.audioTrack,
       videoTrack: participant.videoTrack,
+      participantName: participant.user_name ? participant.user_name : 'Guest',
     };
     if (participant.screenVideoTrack || participant.screenAudioTrack) {
       callItems[id + '-screen'] = {

--- a/react-demo/src/components/StartButton/StartButton.css
+++ b/react-demo/src/components/StartButton/StartButton.css
@@ -2,7 +2,7 @@
   padding: 20px 30px;
   position: absolute;
   background: #ffffff;
-  font-family: Helvetica Neue;
+  font-family: 'Helvetica Neue';
   font-style: normal;
   font-weight: normal;
   font-size: 14px;
@@ -12,5 +12,4 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background-color: #ffffff;
 }

--- a/react-demo/src/components/Tile/Tile.css
+++ b/react-demo/src/components/Tile/Tile.css
@@ -13,6 +13,7 @@
   width: 100%;
   position: absolute;
   top: 0px;
+  z-index: 1;
 }
 
 .tile .background {
@@ -42,4 +43,20 @@
   transform: translate(-50%, -50%);
   font-size: 14px;
   line-height: 17px;
+}
+
+.participant-name {
+  padding: 5px 5px;
+  position: absolute;
+  background: #ffffff;
+  font-family: 'Helvetica Neue';
+  font-style: normal;
+  font-weight: normal;
+  font-size: 1rem;
+  line-height: 13px;
+  text-align: center;
+  color: #4a4a4a;
+  top: 0;
+  left: 0;
+  z-index: 10;
 }

--- a/react-demo/src/components/Tile/Tile.js
+++ b/react-demo/src/components/Tile/Tile.js
@@ -1,10 +1,12 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
+// import CallObjectContext from '../../CallObjectContext';
 import './Tile.css';
 
 /**
  * Props
  * - videoTrack: MediaStreamTrack?
  * - audioTrack: MediaStreamTrack?
+ * - participantName: Does the participant have a .user_name?
  * - isLocalPerson: boolean
  * - isLarge: boolean
  * - isLoading: boolean
@@ -54,12 +56,23 @@ export default function Tile(props) {
     return classNames;
   }
 
+  function getParticipantName() {
+    return (
+      props.participantName && (
+        <div className="participant-name">{props.participantName}</div>
+      )
+    );
+  }
+
   return (
-    <div className={getClassNames()} onClick={props.onClick}>
-      <div className="background" />
-      {getLoadingComponent()}
-      {getVideoComponent()}
-      {getAudioComponent()}
+    <div>
+      <div className={getClassNames()} onClick={props.onClick}>
+        <div className="background" />
+        {getLoadingComponent()}
+        {getVideoComponent()}
+        {getAudioComponent()}
+        {getParticipantName()}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
I'll plan on chatting this over with you in 1:1 tomorrow, @philmillman ! To follow Paul's pattern, I: 

* Added a `participantName:` to the `callItems` state in callState.js 
* Passed that down to <Tile> in Call.js 
* In Tile.js, call a function that grabs the name. 
* There's minor styling that positions the name overlay, for now. 

I'm not sure if we'll actually want to merge this, but before I used this sample code in a blog I wanted to review with you. Thank you! 